### PR TITLE
Add switch to pretty print DSC verbose output

### DIFF
--- a/POSHOrigin/Functions/Invoke-POSHOriginNEW.ps1
+++ b/POSHOrigin/Functions/Invoke-POSHOriginNEW.ps1
@@ -43,7 +43,7 @@ function Invoke-POSHOriginNEW {
         [Alias('Resource')]
         [psobject[]]$InputObject,
 
-        [switch]$NoTranslate,
+        #[switch]$NoTranslate,
         
         [switch]$PrettyPrint,
 

--- a/POSHOrigin/Functions/Invoke-POSHOriginNEW.ps1
+++ b/POSHOrigin/Functions/Invoke-POSHOriginNEW.ps1
@@ -11,8 +11,6 @@ function Invoke-POSHOriginNEW {
             ** THIS IS AN EXPERIMENTAL CMDLET AND MAY BE SIGNIFICANTLY MODIFIED IN FUTURE VERSIONS **
         .PARAMETER InputObject
             One or more custom objects containing the required options for the DSC resource to be provisioned.
-        .PARAMETER NoTranslate
-            Do not call the Invoke.ps1 script from the DSC resource module. Instead pass the object directly to Invoke-DscResource without translation.
         .PARAMETER WhatIf
             Only execute the TEST functionality of DSC.
             


### PR DESCRIPTION
Add a `-PrettyPrint` switch to the experimental function `Invoke-POSHOriginNew`. This will parse the verbose output of the DSC resource and only show relevant information.
