### PR TITLE
Add support for using a git repository as the source of a module

### DIFF
--- a/POSHOrigin/Functions/Get-POSHOriginConfig.ps1
+++ b/POSHOrigin/Functions/Get-POSHOriginConfig.ps1
@@ -60,6 +60,10 @@ function Get-POSHOriginConfig {
     }
 
     end {
+
+        # Remove any downloaded git-based modules
+        _CleanupDownloadedModules.ps1        
+        
         $script:credentialCache = @{}
         $script:modulesToProcess = @{}
         $script:resourceCache = @{}

--- a/POSHOrigin/Functions/Invoke-POSHOrigin.ps1
+++ b/POSHOrigin/Functions/Invoke-POSHOrigin.ps1
@@ -131,6 +131,9 @@ function Invoke-POSHOrigin {
             # Reset the progress bar preference
             $global:ProgressPreference = $oldProgPref
 
+            # Remove any downloaded git-based modules
+            _CleanupDownloadedModules.ps1
+
             Write-Debug -Message $msgs.ipo_end
         } else {
             Write-Error -Message $msgs.ipo_mof_failure

--- a/POSHOrigin/Functions/New-POSHOriginResourceFromModule.ps1
+++ b/POSHOrigin/Functions/New-POSHOriginResourceFromModule.ps1
@@ -1,28 +1,44 @@
 
 function New-POSHOriginResourceFromModule {
     <#
-        .SYNOPSIS
-            Returns POSHOrigin resource(s) defined in a given folder.
-        .DESCRIPTION
-            Returns POSHOrigin resource(s) defined in a given folder. If a .ps1 script with the same name as the module folder is found, only that 
-            script will be invoked. That script (the module entry point) is responsible for containing logic to process and return any needed
-            POSHOrigin resources defined in the module. If Additionaly options are specified for the module, those options will be passed to the 
-            module entry point script.
-        .PARAMETER Name
-            The name of the POSHOrigin module
-        .PARAMETER Options
-            Hashtable of options to pass to POSHOrigin module.
-        .EXAMPLE
-            Returns all POSHOrigin resources defined in the module 'compute_xl_gold' at location '.\modules\compute\xl_gold'. The POSHOrigin module
-            contains a script with the same name as the folder 'xl_gold.ps1' which is responsible for returning the actual POSHOrigin resources for
-            the module.
-            
-            The alias 'module' is usually used instead of the full cmdlet name New-POSHOriginResourceFromModule.
-            
-            module 'compute_xl_gold' @{
-                source = '.\modules\compute\xl_gold'
-                name = "server$_"
-            }
+    .SYNOPSIS
+        Returns POSHOrigin resource(s) defined in a given folder or git repository.
+    .DESCRIPTION
+        Returns POSHOrigin resource(s) defined in a given folder or git repository. If a .ps1 script with the same name as the module folder is
+        found, only that script will be invoked. That script (the module entry point) is responsible for containing logic to process and return
+        any needed POSHOrigin resources defined in the module. If additional options are specified for the module, those options will be passed
+        to the module entry point script.
+    .PARAMETER Name
+        The name of the POSHOrigin module
+    .PARAMETER Options
+        Hashtable of options to pass to POSHOrigin module.
+
+        At a minimum, a property called 'Source' must be specified. The source property can point to a local file/folder, a file/folder on an
+        SMB share, or a git URL in the format of 'git://hostname.mydomain.tld/username/repo.git'. If pointing to a git URL, 'git.exe' must be
+        available in the user's path.        
+    .EXAMPLE
+        Returns all POSHOrigin resources defined in the module 'compute_xl_gold' at location '.\modules\compute\xl_gold'. The POSHOrigin module
+        contains a script with the same name as the folder 'xl_gold.ps1' which is responsible for returning the actual POSHOrigin resources for
+        the module.
+        
+        The alias 'module' is usually used instead of the full cmdlet name New-POSHOriginResourceFromModule.
+        
+        module 'compute_xl_gold' @{
+            source = '.\modules\compute\xl_gold'
+            name = "server$_"
+        }
+    .EXAMPLE
+        Returns all POSHOrigin resources defined in the module 'gitmodule' at location 'git://github.com/<username>/<module>.git'. POSHOrigin
+        will clone this repository into a temporary folder and execute the resources contained within. If there is a file at the root of the
+        repository with the same name as the repository, that script (the entry point script) will be the only file executed and it will be
+        passed any additional parameters specified with the module minus the <Source> property. After executing the resources, the temporary
+        folder will be deleted. 
+
+        module 'gitmodule' @{
+            source = 'git://github.com/<username>/<module>.git'
+            param1 = 'foo'
+            param2 = 'bar'
+        }
     #>
     param(
         [parameter(mandatory, position = 0)]
@@ -33,92 +49,90 @@ function New-POSHOriginResourceFromModule {
     )
 
     if ($Options.ContainsKey('Source')) {
-        if ([System.IO.Path]::IsPathRooted($Options.source)) {
-            $path = $Options.source
-        } else {
-            $here = $MyInvocation.PSScriptRoot
-            $path = Join-Path -Path $here -ChildPath $Options.Source -Resolve
-        }
 
-        if (-Not $script:modulesToProcess.ContainsKey($path)) {
-            if (Test-Path -Path $path) {
+        # Is Source a git url?
+        if ($Options.source -match '^git://*') {
 
-                $callEntryPoint = $false
-                $modParams = _CopyObject -DeepCopyObject $Options
-                $modParams.Remove('Source')
-
-                $modItem = Get-Item -Path $Path
-                $modFiles = @()
-
-                Write-Verbose -Message "  Module: $Name - Path: $Path"
-
-                if ($modItem.PSIsContainer) {
-                    # We specified a module folder
-                    # Are we trying to pass extra items to module?
-                    # If so, we just want to run the module entry point script
-                    # and not all the files in the module
-                    $folderName = Split-Path -Path $path -Leaf
-                    if ($modParams.Count -gt 0) {
-                        $callEntryPoint = $true
-                        $folderName = Split-Path -Path $path -Leaf
-                        $modFiles = Get-Item -Path (Join-Path -Path $path -ChildPath "$folderName.ps1")
-                    } else {
-                        # Run all files in module except the entry point script if it exists
-                        Write-Verbose -Message "    Specified module folder. Loading all files within"
-                        $modFiles = Get-ChildItem -Path $modItem -File -Filter '*.ps1' -Exclude "$folderName.ps1" -Recurse
-                    }
-                } else {
-                    # Are we calling the entry point script directly?
-                    $folderName = Split-Path -Path $path -Parent
-                    if ($modItem.BaseName -eq $folderName) {
-                        $callEntryPoint = $true
-                    }
-                    $modFiles = $modItem
-                }
-
-                $configdata = @()
-                foreach ($modFile in $modFiles) {
-                    if ($callEntryPoint) {
-                        # Call entry point script and pass params
-                        $configdata += @(. $modFile @modParams)
-                    } else {
-                        # Call script with no params
-                        $configdata += @(. $modFile @modParams)
-                    }
-                }
-
-                return $configData
-
-
-                ##$modFile = $modFile.FullName
-
-                ##if ($modFile) {
-
-                    
-                    
-
-                ##     Is this a smart module? If so just process the entry script
-                ##     and not all the files in the module
-                ##    if ($smartMod) {
-                        
-                ##    } else {
-                ##        $script:modulesToProcess.Add($path, $name)
-                ##        $files = Get-ChildItem -Path $path -File -Filter '*.ps1' -Recurse
-                ##        Write-Verbose -Message "Module: $Name - Items: $($files.Count) - Path: $modFile"
-                ##        $files | ForEach-Object {
-                ##            $configdata += @(. $_.FullName @modParams)
-                ##        }
-                ##    }
-                ##    return $configData
-                ##} else {
-                ##    throw ($msgs.nporff_module_not_found -f $Path)
-                ##}
+            # See if we've all ready downloaded this module as part of this POSHOrigin execution
+            # If so, just use the previously downloaded location
+            if (-not $script:gitModulesProcessed.ContainsKey($Options.source)) {
+                $path = _GetGenericGitRepo -Url $Options.Source
+                $script:gitModulesProcessed.Add($Options.source, $path)
             } else {
-                throw ($msgs.nporff_module_not_found -f $path)
+                $path = $script:gitModulesProcessed[$Options.source]
             }
         } else {
-            Write-Warning -Message "Module $Name($path) has already been referenced by another configuration and will not be processed again"
+            # Source is a local directory
+            if ([System.IO.Path]::IsPathRooted($Options.source)) {
+                $path = $Options.source
+            } else {
+                $here = $MyInvocation.PSScriptRoot
+                $path = Join-Path -Path $here -ChildPath $Options.Source -Resolve
+            }
         }
+        
+        if ($Path) {
+            if (-Not $script:modulesToProcess.ContainsKey($path)) {
+                if (Test-Path -Path $path) {
+
+                    $callEntryPoint = $false
+                    $modParams = _CopyObject -DeepCopyObject $Options
+                    $modParams.Remove('Source')
+
+                    $modItem = Get-Item -Path $Path
+                    $modFiles = @()
+
+                    Write-Verbose -Message "  Module: $Name - Path: $Path"
+
+                    if ($modItem.PSIsContainer) {
+                        # We specified a module folder
+                        # Are we trying to pass extra items to module or does a script
+                        # with the same name as the folder exist?
+                        # If so, we just want to run the module entry point script
+                        # and not all the files in the module
+
+                        $folderName = Split-Path -Path $path -Leaf
+                        $entryPointScript = (Join-Path -Path $path -ChildPath "$folderName.ps1")
+                        
+                        if (($modParams.Count -gt 0) -or (Test-Path -Path $entryPointScript)) {
+                            $callEntryPoint = $true
+                            Write-Verbose -Message "    Executing module entry point script [$entryPointScript]"
+                            $modFiles = Get-Item -Path $entryPointScript
+                        } else {
+                            # Run all files in module except the entry point script if it exists
+                            Write-Verbose -Message "    Specified module folder. Loading all files within"
+                            $modFiles = Get-ChildItem -Path $modItem -File -Filter '*.ps1' -Exclude "$folderName.ps1" -Recurse
+                        }
+                    } else {
+                        # Are we calling the entry point script directly?
+                        $folderName = Split-Path -Path $path -Parent
+                        if ($modItem.BaseName -eq $folderName) {
+                            $callEntryPoint = $true
+                        }
+                        $modFiles = $modItem
+                    }
+
+                    # Execute POSHOrigin files
+                    $configdata = @()
+                    foreach ($modFile in $modFiles) {
+                        if ($callEntryPoint) {
+                            # Call entry point script and pass params
+                            $configdata += @(. $modFile @modParams)
+                        } else {
+                            # Call script with no params
+                            $configdata += @(. $modFile @modParams)
+                        }
+                    }
+                    return $configData
+                } else {
+                    throw ($msgs.nporff_module_not_found -f $path)
+                }
+            } else {
+                Write-Warning -Message "Module $Name($path) has already been referenced by another configuration and will not be processed again"
+            }
+        } else {
+            Write-Error -Message "Unable to retrieve module from source [$Source]"
+        }        
     } else {
         throw $msgs.nporff_no_source
     }

--- a/POSHOrigin/Internal/_CleanupDownloadedModules.ps1
+++ b/POSHOrigin/Internal/_CleanupDownloadedModules.ps1
@@ -1,0 +1,16 @@
+
+function _CleanupDownloadedModules.ps1 {
+    [cmdletbinding()]
+    param()
+
+    # Remove any downloaded git-based modules
+    if ($script:gitModulesProcessed.Keys.Count -gt 0) {
+        foreach ($moduleSource in $script:gitModulesProcessed.Keys) {
+            $modulePath = $script:gitModulesProcessed[$ModuleSource]
+            $parent = Split-Path -Path $modulePath -Parent
+            Write-Debug -Message "Removing temporary module path [$parent] for module [$moduleSource]"                    
+            Remove-Item -Path $parent -Force -Recurse
+        }
+    }
+    $script:gitModulesProcessed = @{}
+}

--- a/POSHOrigin/Internal/_GetGenericGitRepo.ps1
+++ b/POSHOrigin/Internal/_GetGenericGitRepo.ps1
@@ -1,0 +1,55 @@
+
+function _GetGenericGitRepo {
+    [cmdletbinding()]
+    param(
+        [string]$Url
+    )   
+
+    try {    
+        # Make sure 'git.exe' is available
+        if (-not (Get-Command -Name 'git.exe') ) {
+            Write-Error -Message 'Unable to find [git.exe] command. Is git installed correctly?'
+            return
+        }
+
+        # Use git to clone repo to temp directory
+        $tempDir =  _NewTempDir
+        Write-Debug -Message "Temp dir created: [($tempDir.FullName)]"
+        Write-Verbose -Message "Cloning repo [$url] to [$($tempDir.FullName)]"    
+
+        # Files to redirect stdout/err to when calling 'git.exe'
+        $stdOutPath = Join-Path -Path $tempDir -ChildPath 'stdOut.txt'
+        $stdErrPath = Join-Path -Path $tempDir -ChildPath 'stdErr.txt'    
+        Write-Debug -Message "stdout log: [($stdOutPath.FullName)]"
+        Write-Debug -Message "stderr log: [($stdErrPath.FullName)]"    
+
+        # Call 'git.exe' to clone the repo
+        $params = @{
+            FilePath = 'git.exe'
+            ArgumentList = @("clone $url")
+            WorkingDirectory = $tempDir
+            RedirectStandardError = $stdErrPath
+            RedirectStandardOutput = $stdOutPath
+            Wait = $true        
+            NoNewWindow = $true
+            PassThru = $true        
+        }
+        $proc = Start-Process @params
+
+        if ($proc.ExitCode -ne 0) {
+            $errs = Get-Content -Path $stdErrPath -Raw
+            Write-Error -Message $errs
+            Remove-Item -Path $stdErrPath -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $stdOutPath -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $tempDir -Force
+        } else {
+            $repoName = Get-ChildItem -Path $tempDir -Directory | Select-Object -First 1
+            $repoPath = (Join-Path -Path $tempDir -ChildPath $repoName)
+            Remove-Item -Path $stdErrPath -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $stdOutPath -Force -ErrorAction SilentlyContinue
+            $repoPath
+        }
+    } catch {
+        Write-Error $_
+    }
+}

--- a/POSHOrigin/Internal/_NewTempDir.ps1
+++ b/POSHOrigin/Internal/_NewTempDir.ps1
@@ -1,0 +1,6 @@
+function _NewTempDir {
+    $parent = [System.IO.Path]::GetTempPath()
+    $name = New-Guid
+    $dir = New-Item -ItemType Directory -Path (Join-Path -Path $parent -ChildPath (New-Guid))
+    $dir
+}

--- a/POSHOrigin/POSHOrigin.psm1
+++ b/POSHOrigin/POSHOrigin.psm1
@@ -10,6 +10,9 @@ $script:credentialCache = @{}
 # cache of modules to process
 $script:modulesToProcess = @{}
 
+# Cache of git-based modules we've processed
+$script:gitModulesProcessed = @{}
+
 # cache of resource names 
 $script:resourceCache = @{}
 


### PR DESCRIPTION
## Description

This PR adds a new capability to **New-POSHOriginResourceFromModule** to reference POSHOrigin configurations stored in a git repository. 
## Related Issue
#19
## Motivation and Context

Allow pre-baked POSHOrigin configurations that are stored in source control to be referenced when defining new resources.
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
